### PR TITLE
Fixes and API

### DIFF
--- a/benchmark/benchmark_loader.py
+++ b/benchmark/benchmark_loader.py
@@ -73,7 +73,8 @@ def evaluate_on(files, method, args):
 			if args.verbose:
 				seq_score_tracker.report(gtp.seqname, kk)
 
-		av_score_tracker.next(gtp.seqname, seq_score_tracker)
+		means = seq_score_tracker.close()
+		av_score_tracker.next(gtp.seqname, means)
 		if args.save_visualization:
 			logger.close()
 

--- a/benchmark/benchmark_loader.py
+++ b/benchmark/benchmark_loader.py
@@ -77,5 +77,5 @@ def evaluate_on(files, method, args):
 		if args.save_visualization:
 			logger.close()
 
-	av_score_tracker.close()
+	return av_score_tracker.close()
 

--- a/benchmark/benchmark_loader.py
+++ b/benchmark/benchmark_loader.py
@@ -46,6 +46,12 @@ def evaluate_on(files, method, args):
 				est_hs, est_traj = method(I,B,bbox_tight,gtp.nsplits,radius,obj_dim,gt_traj)
 			else:
 				est_hs, est_traj = method(I,B,bbox_tight,gtp.nsplits,radius,obj_dim)
+
+			if est_hs is None:
+				if args.verbose:
+					print(f"method() returned None, skipping frame {kk}")
+				continue
+
 			av_score_tracker.next_time(time.time() - start)
 
 			gt_hs_crop = crop_only(gt_hs, bbox_tight)

--- a/benchmark/benchmark_loader.py
+++ b/benchmark/benchmark_loader.py
@@ -1,8 +1,8 @@
 import os
 import numpy as np
 import time
-from benchmark.loaders_helpers import *
-from benchmark.reporters import *
+from .loaders_helpers import *
+from .reporters import *
 
 def run_benchmark(args, method):
 	files = get_falling_dataset(args.falling_path)

--- a/benchmark/benchmark_loader.py
+++ b/benchmark/benchmark_loader.py
@@ -12,7 +12,7 @@ def run_benchmark(args, method):
 	files = get_tbd_dataset(args.tbd_path)
 	evaluate_on(files, method, args)
 	
-def evaluate_on(files, method, args):
+def evaluate_on(files, method, args, callback=None):
 	dataset_name = os.path.split(os.path.split(os.path.split(files[0])[0])[0])[-1]
 	log_folder = os.path.join(args.visualization_path, dataset_name+'_eval/')
 	medn = 50
@@ -77,6 +77,9 @@ def evaluate_on(files, method, args):
 		av_score_tracker.next(gtp.seqname, means)
 		if args.save_visualization:
 			logger.close()
+
+		if callback:
+			callback(kkf, means)
 
 	return av_score_tracker.close()
 

--- a/benchmark/loaders_helpers.py
+++ b/benchmark/loaders_helpers.py
@@ -96,12 +96,14 @@ def imread(name):
 		return img[:,:,[2,1,0,3]]/65535
 
 def imwrite(im, name):
+    im = im.copy()
     im[im<0]=0
     im[im>1]=1
     cv2.imwrite(name, im[:,:,[2,1,0]]*255)
 
 
 def extend_bbox(bbox,ext,aspect_ratio,shp):
+    bbox = bbox.copy()
     height, width = bbox[2] - bbox[0], bbox[3] - bbox[1]
             
     h2 = height + ext
@@ -124,6 +126,7 @@ def extend_bbox(bbox,ext,aspect_ratio,shp):
     return bbox
 
 def extend_bbox_uniform(bbox,ext,shp):
+    bbox = bbox.copy()
     bbox[0] -= ext
     bbox[2] += ext
     bbox[1] -= ext
@@ -182,6 +185,7 @@ def crop_only(Is, bbox):
     return Is[bbox[0]:bbox[2], bbox[1]:bbox[3]]
 
 def rev_crop_resize_traj(inp, bbox, res):
+    inp = inp.copy()
     inp[0] *= ( (bbox[2]-bbox[0])/res[1])
     inp[1] *= ( (bbox[3]-bbox[1])/res[0])
     inp[0] += bbox[0]
@@ -211,6 +215,7 @@ def write_trajectory(Img, traj):
     
 
 def renderTraj(pars, H):
+    H = H.copy()
     ## Input: pars is either 2x2 (line) or 2x3 (parabola)
     if pars.shape[1] == 2:
         pars = np.concatenate( (pars, np.zeros((2,1))),1)

--- a/benchmark/loaders_helpers.py
+++ b/benchmark/loaders_helpers.py
@@ -177,7 +177,7 @@ def crop_resize(Is, bbox, res):
         imr[:,:,:,kk] = cv2.resize(im, res, interpolation = cv2.INTER_CUBIC)
     if rev_axis:
         imr = imr[:,:,:,0]
-    return imr
+    return np.clip(imr, 0, 1)
 
 def crop_only(Is, bbox):
     if Is is None:

--- a/benchmark/reporters.py
+++ b/benchmark/reporters.py
@@ -2,7 +2,7 @@ import numpy as np
 import os, glob
 import scipy.io
 import cv2
-from benchmark.loaders_helpers import *
+from .loaders_helpers import *
 
 class GroundTruthProcessor:
 	def __init__(self, seqpath, kkf, medn):

--- a/benchmark/reporters.py
+++ b/benchmark/reporters.py
@@ -138,8 +138,10 @@ class AverageScoreTracker:
 
 	def close(self):
 		print('AVERAGES')
-		print('{}: TIoU {:.3f}, PSNR {:.3f} dB, SSIM {:.3f}'.format(self.algname, np.nanmean(self.av_ious), np.nanmean(self.av_psnr), np.nanmean(self.av_ssim)))
+		means = np.nanmean(self.av_ious), np.nanmean(self.av_psnr), np.nanmean(self.av_ssim)
+		print('{}: TIoU {:.3f}, PSNR {:.3f} dB, SSIM {:.3f}'.format(self.algname, *means))
 		print('{}: time {:.3f} seconds'.format(self.algname, np.nanmean(np.array(self.av_times))))
+		return means
 
 #######################################################################################################################
 #######################################################################################################################

--- a/benchmark/reporters.py
+++ b/benchmark/reporters.py
@@ -127,9 +127,9 @@ class AverageScoreTracker:
 		self.algname = algname
 
 	def next(self, seqname, sst):
-		self.av_ious[self.seqi] = np.mean(sst.all_ious)
-		self.av_psnr[self.seqi] = np.mean(sst.all_psnr)
-		self.av_ssim[self.seqi] = np.mean(sst.all_ssim)
+		self.av_ious[self.seqi] = np.mean(sst.all_ious.values())
+		self.av_psnr[self.seqi] = np.mean(sst.all_psnr.values())
+		self.av_ssim[self.seqi] = np.mean(sst.all_ssim.values())
 		print('{}: Finished seq {}, avg. TIoU {:.3f}, PSNR {:.3f} dB, SSIM {:.3f}'.format(self.algname,seqname, self.av_ious[self.seqi], self.av_psnr[self.seqi], self.av_ssim[self.seqi]))
 		self.seqi += 1
 
@@ -146,9 +146,9 @@ class AverageScoreTracker:
 
 class SequenceScoreTracker:
 	def __init__(self, nfrms, algname):
-		self.all_ious = np.zeros(nfrms)
-		self.all_psnr = np.zeros(nfrms)
-		self.all_ssim = np.zeros(nfrms)
+		self.all_ious = {}
+		self.all_psnr = {}
+		self.all_ssim = {}
 		self.algname = algname
 
 	def next_traj(self,kk,gt_traj,est_traj,minor_axis_length):

--- a/benchmark/reporters.py
+++ b/benchmark/reporters.py
@@ -126,10 +126,8 @@ class AverageScoreTracker:
 		self.seqi = 0
 		self.algname = algname
 
-	def next(self, seqname, sst):
-		self.av_ious[self.seqi] = np.mean(sst.all_ious.values())
-		self.av_psnr[self.seqi] = np.mean(sst.all_psnr.values())
-		self.av_ssim[self.seqi] = np.mean(sst.all_ssim.values())
+	def next(self, seqname, means):
+		self.av_ious[self.seqi], self.av_psnr[self.seqi], self.av_ssim[self.seqi] = means
 		print('{}: Finished seq {}, avg. TIoU {:.3f}, PSNR {:.3f} dB, SSIM {:.3f}'.format(self.algname,seqname, self.av_ious[self.seqi], self.av_psnr[self.seqi], self.av_ssim[self.seqi]))
 		self.seqi += 1
 
@@ -165,7 +163,14 @@ class SequenceScoreTracker:
 		self.all_ssim[kk] = calculate_ssim(gt_hs, est_hs)
 
 	def report(self, seqname, kk):
-		print('{}: Seq {}, frm {}, TIoU {:.3f}, PSNR {:.3f} dB, SSIM {:.3f}'.format(self.algname, seqname, kk, self.all_ious[kk], self.all_psnr[kk], self.all_ssim[kk]))
+		print('{}: Seq {}, frm {}, TIoU {:.3f}, PSNR {:.3f} dB, SSIM {:.3f}'.format(self.algname, seqname, kk, self.all_ious.get(kk, 0), self.all_psnr[kk], self.all_ssim[kk]))
+
+	def close(self):
+		return (
+			np.mean(list(self.all_ious.values())) if self.all_ious else 0,
+			np.mean(list(self.all_psnr.values())) if self.all_psnr else 0,
+			np.mean(list(self.all_ssim.values())) if self.all_ssim else 0
+		)
 
 #######################################################################################################################
 #######################################################################################################################


### PR DESCRIPTION
These are the changes I made to be able to be able to integrate the benchmark in my code and run it for double blur inputs.

None of these changes should alter existing behavior and results.

- copy inputs in certain methods to avoid unexpected side effects
- return calculated values instead of only printing them, so the results can be used by calling code
- clip cubic interpolation to valid range
- allow user-defined method to return None to skip that input
- add optional callback to be called after every input sequence, for example for cleanup